### PR TITLE
EODHP-387 add workspace setting to pycalrissian

### DIFF
--- a/pycalrissian/context.py
+++ b/pycalrissian/context.py
@@ -20,6 +20,7 @@ class CalrissianContext:
         namespace: str,
         storage_class: str,
         volume_size: str,
+        service_account: str = "default",
         resource_quota: Dict = None,
         image_pull_secrets: Dict = None,
         kubeconfig_file: TextIO = None,
@@ -49,6 +50,7 @@ class CalrissianContext:
         self.namespace = namespace
         self.storage_class = storage_class
         self.volume_size = volume_size
+        self.service_account = service_account
 
         self.resource_quota = resource_quota
 
@@ -118,7 +120,7 @@ class CalrissianContext:
             logger.info(f"create secret {self.secret_name}")
             self.create_image_pull_secret(self.secret_name)
 
-            logger.info("patch service account")
+            logger.info(f"patch service account {self.service_account}")
             self.patch_service_account()
 
         if self.resource_quota:
@@ -379,7 +381,7 @@ class CalrissianContext:
         subject = client.models.V1Subject(
             api_group="",
             kind="ServiceAccount",
-            name="default",
+            name=self.service_account,
             namespace=self.namespace,
         )
 
@@ -587,7 +589,7 @@ class CalrissianContext:
         # adds a secret to the namespace default service account
 
         service_account_body = self.core_v1_api.read_namespaced_service_account(
-            name="default", namespace=self.namespace
+            name=self.service_account, namespace=self.namespace
         )
 
         if service_account_body.secrets is None:
@@ -603,7 +605,7 @@ class CalrissianContext:
 
         try:
             self.core_v1_api.patch_namespaced_service_account(
-                name="default",
+                name=self.service_account,
                 namespace=self.namespace,
                 body=service_account_body,
                 pretty=True,

--- a/pycalrissian/job.py
+++ b/pycalrissian/job.py
@@ -56,7 +56,7 @@ class CalrissianJob:
         self.max_ram = max_ram
         self.max_cores = max_cores
         self.security_context = security_context
-        self.service_account = service_account
+        self.service_account = runtime_context.service_account
         self.storage_class = storage_class  # check this, is it needed?
         self.debug = debug
         self.no_read_only = no_read_only
@@ -256,7 +256,9 @@ class CalrissianJob:
             ],
             volumes=volumes,
             security_context=self.security_context,
+            service_account=self.service_account,
         )
+        logger.info(f"Created pod template with service account {self.service_account}")
 
         return self.create_job(
             name=self.job_name,
@@ -293,7 +295,7 @@ class CalrissianJob:
 
     @staticmethod
     def create_pod_template(
-        name, containers, volumes, security_context, node_selector=None
+        name, containers, volumes, security_context, service_account, node_selector=None
     ):
         """Creates the pod template with the three containers"""
 
@@ -309,6 +311,7 @@ class CalrissianJob:
                     fs_group=security_context["fsGroup"],
                 ),
                 termination_grace_period_seconds=120,
+                service_account_name=service_account,
             ),
             metadata=client.V1ObjectMeta(name=name, labels={"pod_name": name}),
         )

--- a/pycalrissian/job.py
+++ b/pycalrissian/job.py
@@ -354,6 +354,8 @@ class CalrissianJob:
             ["--max-ram", f"{self.max_ram}", "--max-cores", f"{self.max_cores}"]
         )
 
+        args.extend(["--pod-serviceaccount", self.service_account])
+
         args.extend(["--tmp-outdir-prefix", f"{self.calrissian_base_path}/"])
 
         args.extend(["--outdir", f"{self.calrissian_base_path}/"])


### PR DESCRIPTION
Service account can be used in pycalrissian. It is used in the pod template, and also passed to calrissian via arg --pod-serviceaccount.
By default the service account is "default"

This has been tested with reading a file in S3 in workflow steps, reading the configmap in stageout, and uploading to S3 at stageout.