### PR TITLE
Add job_id to params configmap

### DIFF
--- a/pycalrissian/execution.py
+++ b/pycalrissian/execution.py
@@ -86,20 +86,24 @@ class CalrissianExecution:
                     data = json.load(staged_file)
                 except json.JSONDecodeError as e:
                     # Common error seen in calrissian output
-                    content = staged_file.read()
-                    # A string often seen added to end of the file which must be removed
-                    sequence = 'q"\n}\n}'
-                    if content.endswith(sequence):
-                        content = content.rsplit(sequence, 1)[0]
-                        try:
-                            data = json.loads(content)
-                            e.msg = None
-                        except json.JSONDecodeError as e:
-                            logger.error(f"Error decoding JSON: {e}")
-                            logger.error(content)
-                            raise e
+                    if e.msg == "Extra data":
+                        count = 0
+                        content = staged_file.read()
+                        # Trim to only first 2 close brackets
+                        for i, char in enumerate(content):
+                            if char == '}':
+                                count += 1
+                            if count == 2:
+                                content = content[:i+1]
+                                break
                     else:
-                        logger.error(f"Error decoding JSON, unrecognised extra data: {e}")
+                        logger.error(f"Error decoding JSON: {e}")
+                        logger.error(content)
+                        raise e
+                    try:
+                        data = json.loads(content)
+                    except json.JSONDecodeError as e:
+                        logger.error(f"Error decoding corrected JSON: {e}")
                         logger.error(content)
                         raise e
                 return data

--- a/pycalrissian/execution.py
+++ b/pycalrissian/execution.py
@@ -82,13 +82,15 @@ class CalrissianExecution:
             filename = self.get_file_from_volume(["output.json"])[0]
             with open(filename, "r") as staged_file:
                 try:
+                    content = staged_file.read()
+                    logger.info(f"Output content is {content}")
+                    staged_file.seek(0)
                     # Attempt to load JSON from file
                     data = json.load(staged_file)
                 except json.JSONDecodeError as e:
                     # Common error seen in calrissian output
                     if e.msg == "Extra data":
                         count = 0
-                        content = staged_file.read()
                         # Trim to only first 2 close brackets
                         for i, char in enumerate(content):
                             if char == '}':
@@ -96,17 +98,18 @@ class CalrissianExecution:
                             if count == 2:
                                 content = content[:i+1]
                                 break
+                        try:
+                            data = json.loads(content)
+                        except json.JSONDecodeError as e:
+                            logger.error(f"Error decoding corrected JSON: {e}")
+                            logger.error(content)
+                            raise e
                     else:
                         logger.error(f"Error decoding JSON: {e}")
                         logger.error(content)
                         raise e
-                    try:
-                        data = json.loads(content)
-                    except json.JSONDecodeError as e:
-                        logger.error(f"Error decoding corrected JSON: {e}")
-                        logger.error(content)
-                        raise e
                 return data
+
 
     def get_usage_report(self) -> Dict:
         """Returns the job usage report"""

--- a/pycalrissian/job.py
+++ b/pycalrissian/job.py
@@ -67,6 +67,7 @@ class CalrissianJob:
         self.tool_logs = tool_logs
         self.calling_workspace = calling_workspace
         self.executing_workspace = executing_workspace
+        self.job_id = job_id
 
         if self.security_context is None:
             logger.info(
@@ -109,7 +110,7 @@ class CalrissianJob:
     def _create_params_cm(self):
         """Create configMap with params"""
         self.runtime_context.create_configmap(
-            name="params", key="params", content=yaml.dump(self.params)
+            name=f"params-{self.job_id}", key="params", content=yaml.dump(self.params)
         )
 
     def _create_pod_env_vars_cm(self):
@@ -176,7 +177,7 @@ class CalrissianJob:
         params_volume = client.V1Volume(
             name="volume-params",
             config_map=client.V1ConfigMapVolumeSource(
-                name="params",
+                name=f"params-{self.job_id}",
                 optional=False,
                 items=[client.V1KeyToPath(key="params", path="params.yml", mode=0o644)],
                 default_mode=0o644,

--- a/pycalrissian/job.py
+++ b/pycalrissian/job.py
@@ -116,7 +116,7 @@ class CalrissianJob:
     def _create_pod_env_vars_cm(self):
         """Create configMap with pod environment variables"""
         self.runtime_context.create_configmap(
-            name=f"pod-env-vars",
+            name="pod-env-vars",
             key="pod-env-vars",
             content=json.dumps(self.pod_env_vars),
         )

--- a/pycalrissian/job.py
+++ b/pycalrissian/job.py
@@ -116,7 +116,7 @@ class CalrissianJob:
     def _create_pod_env_vars_cm(self):
         """Create configMap with pod environment variables"""
         self.runtime_context.create_configmap(
-            name="pod-env-vars",
+            name=f"pod-env-vars-{self.job_id}",
             key="pod-env-vars",
             content=json.dumps(self.pod_env_vars),
         )
@@ -124,7 +124,7 @@ class CalrissianJob:
     def _create_pod_node_selector_cm(self):
         """Create configMap with pod node selector"""
         self.runtime_context.create_configmap(
-            name="pod-node-selector",
+            name=f"pod-node-selector-{self.job_id}",
             key="pod-node-selector",
             content=json.dumps(self.pod_node_selector),
         )
@@ -214,7 +214,7 @@ class CalrissianJob:
             pod_env_vars_volume = client.V1Volume(
                 name="volume-pod-env-vars",
                 config_map=client.V1ConfigMapVolumeSource(
-                    name="pod-env-vars",
+                    name=f"pod-env-vars-{self.job_id}",
                     optional=False,
                     items=[
                         client.V1KeyToPath(
@@ -237,7 +237,7 @@ class CalrissianJob:
             pod_node_selector_volume = client.V1Volume(
                 name="volume-pod-node-selector",
                 config_map=client.V1ConfigMapVolumeSource(
-                    name="pod-node-selector",
+                    name=f"pod-node-selector-{self.job_id}",
                     optional=False,
                     items=[
                         client.V1KeyToPath(

--- a/pycalrissian/job.py
+++ b/pycalrissian/job.py
@@ -104,7 +104,7 @@ class CalrissianJob:
     def _create_cwl_cm(self):
         """Create configMap with CWL"""
         self.runtime_context.create_configmap(
-            name="cwl-workflow", key="cwl-workflow", content=yaml.dump(self.cwl)
+            name=f"cwl-workflow-{self.job_id}", key="cwl-workflow", content=yaml.dump(self.cwl)
         )
 
     def _create_params_cm(self):
@@ -116,7 +116,7 @@ class CalrissianJob:
     def _create_pod_env_vars_cm(self):
         """Create configMap with pod environment variables"""
         self.runtime_context.create_configmap(
-            name="pod-env-vars",
+            name=f"pod-env-vars",
             key="pod-env-vars",
             content=json.dumps(self.pod_env_vars),
         )
@@ -158,7 +158,7 @@ class CalrissianJob:
         workflow_volume = client.V1Volume(
             name="volume-cwl-workflow",
             config_map=client.V1ConfigMapVolumeSource(
-                name="cwl-workflow",
+                name=f"cwl-workflow-{self.job_id}",
                 optional=False,
                 items=[
                     client.V1KeyToPath(


### PR DESCRIPTION
## Ensure params config maps are unique
- There is a risk job parameters get mixed up as they are inserted into job using a single configmap that is overwritten
- This ensures configmaps are created uniquely for each job, using the `job_id`